### PR TITLE
Enforce HINOTE_TOKEN at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install -e .
 
 2. Place your music files under the `music/` directory or set the `MUSIC_DIR` environment variable.
 
-3. Start the server:
+3. Start the server (the `HINOTE_TOKEN` environment variable is **required**):
 
 ```bash
 HINOTE_TOKEN=yourtoken python -m hinote

--- a/hinote/main.py
+++ b/hinote/main.py
@@ -8,7 +8,11 @@ from typing import List, Dict
 from .indexer import scan_music_directory
 from .player import state
 
-API_TOKEN = os.getenv("HINOTE_TOKEN", "secret")
+API_TOKEN = os.getenv("HINOTE_TOKEN")
+if not API_TOKEN:
+    raise RuntimeError(
+        "HINOTE_TOKEN environment variable must be set before starting HiNote"
+    )
 MUSIC_DIR = os.getenv("MUSIC_DIR", "music")
 
 app = FastAPI(title="HiNote")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+import sys
+import pytest
+
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+
+def test_fail_without_token(monkeypatch):
+    monkeypatch.delenv("HINOTE_TOKEN", raising=False)
+    sys.modules.pop("hinote.main", None)
+    with pytest.raises(RuntimeError):
+        importlib.import_module("hinote.main")


### PR DESCRIPTION
## Summary
- require `HINOTE_TOKEN` for startup instead of using a default token
- document the required environment variable in README
- add a test ensuring the server fails to start without the token

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688285e30130832e950157155b82bb0f