### PR TITLE
Add tests for auth and songs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ HINOTE_TOKEN=yourtoken python -m hinote
 
 4. On your mobile device, navigate to `http://<server-ip>:8000`, enter the token, and start playing your music.
 
+## Running tests
+
+After installing the dependencies and the package in editable mode you can run the automated tests with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+pytest
+```
+
 ## Notes
 
 This is a minimal reference implementation. Advanced features like persistent state, output device selection, or casting are left as future improvements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 mutagen
 Jinja2
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,27 @@
+import importlib
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Fixture to create TestClient with temporary music directory
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("MUSIC_DIR", str(tmp_path))
+    monkeypatch.setenv("HINOTE_TOKEN", "testtoken")
+    import hinote.main as main
+    importlib.reload(main)
+    with TestClient(main.app) as c:
+        yield c
+
+
+def test_get_songs_requires_auth(client):
+    response = client.get("/api/songs")
+    assert response.status_code == 401
+
+
+def test_get_songs_returns_list(client):
+    headers = {"Authorization": "Bearer testtoken"}
+    response = client.get("/api/songs", headers=headers)
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)


### PR DESCRIPTION
## Summary
- create `tests/` with API tests
- document how to run tests
- include httpx in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688285e1fbe0832eadb9fc7d73468197